### PR TITLE
add calendarType iota

### DIFF
--- a/cldr.go
+++ b/cldr.go
@@ -769,6 +769,8 @@ var calendarMonthNames = [...]calendarMonths{
 	{"Januwari", "Februwari", "Mashi", "Ephreli", "Meyi", "Juni", "Julayi", "Agasti", "Septhemba", "Okthoba", "Novemba", "Disemba"},
 }
 
+// monthIndexes contains indexes of months names, each calendar has 6 indexes
+// for all variations of "width" and "context".
 type monthIndexes [18]int16
 
 var monthLookup = map[string]monthIndexes{
@@ -1640,19 +1642,10 @@ var monthLookup = map[string]monthIndexes{
 	"zu-ZA":          {749, 749, 751, 751, 750, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 }
 
-func fmtMonth(locale, calendar, context, width string) func(int, string) string {
+func fmtMonth(locale string, calendar calendarType, context, width string) func(int, string) string {
 	indexes := monthLookup[locale]
 
-	var i int
-
-	switch calendar {
-	case "gregorian": // noop
-		// "gregorian" calendar index is 0
-	case "buddhist":
-		i = 6 // 1*3*2
-	case "persian":
-		i = 12 // 2*3*2
-	}
+	i := calendar * 6
 
 	// "abbreviated" width index is 0
 	switch width {
@@ -1789,16 +1782,16 @@ func defaultNumberingSystem(locale language.Tag) numberingSystem {
 	}
 }
 
-func defaultCalendar(locale language.Tag) string {
+func defaultCalendar(locale language.Tag) calendarType {
 	switch v, _ := locale.Region(); v.String() {
 	default:
-		return "gregorian"
+		return calendarTypeGregorian
 	case "AF", "IR":
-		return "persian"
+		return calendarTypePersian
 	case "SA":
-		return "islamic-umalqura"
+		return calendarTypeIslamicUmalqura
 	case "TH":
-		return "buddhist"
+		return calendarTypeBuddhist
 	}
 }
 
@@ -1893,9 +1886,9 @@ func fmtMonthGregorian(locale language.Tag, digits digits) func(month int, forma
 	default:
 		return fmt
 	case "wae":
-		return fmtMonth(locale.String(), "gregorian", "stand-alone", "abbreviated")
+		return fmtMonth(locale.String(), calendarTypeGregorian, "stand-alone", "abbreviated")
 	case "mn":
-		return fmtMonth(locale.String(), "gregorian", "stand-alone", "narrow")
+		return fmtMonth(locale.String(), calendarTypeGregorian, "stand-alone", "narrow")
 	case "br", "fo", "ga", "lt", "uk", "uz":
 		return func(m int, f string) string { return fmt(m, "01") }
 	case "root", "aa", "ab", "af", "agq", "ak", "am", "an", "ann", "apc", "ar", "arn", "as", "asa", "ast", "az", "ba", "bal", "bas", "be", "bem", "bew", "bez", "bg", "bgc", "bgn", "bho", "blo", "blt", "bm", "bn", "bo", "brx", "bs", "bss", "byn", "ca", "cad", "cch", "ccp", "ce", "ceb", "cgg", "cho", "chr", "cic", "ckb", "co", "cs", "csw", "cu", "cv", "cy", "da", "dav", "de", "dje", "doi", "dsb", "dua", "dv", "dyo", "dz", "ebu", "ee", "el", "en", "eo", "es", "et", "eu", "ewo", "fa", "ff", "fi", "fil", "fr", "fur", "fy", "gaa", "gd", "gez", "gl", "gn", "gsw", "gu", "guz", "gv", "ha", "haw", "he", "hi", "hnj", "hsb", "hu", "hy", "ia", "id", "ie", "ig", "ii", "io", "is", "it", "iu", "jbo", "jgo", "jmc", "jv", "ka", "kab", "kaj", "kam", "kcg", "kde", "kea", "ken", "kgp", "khq", "ki", "kk", "kkj", "kl", "kln", "km", "kn", "kok", "kpe", "ks", "ksb", "ksf", "ksh", "ku", "kw", "kxv", "ky", "la", "lag", "lb", "lg", "lij", "lkt", "lmo", "ln", "lo", "lrc", "lu", "luo", "luy", "lv", "mai", "mas", "mdf", "mer", "mfe", "mg", "mgh", "mgo", "mi", "mic", "mk", "ml", "mni", "moh", "mr", "ms", "mt", "mua", "mus", "my", "myv", "mzn", "naq", "nd", "nds", "ne", "nl", "nmg", "nnh", "nqo", "nr", "nso", "nus", "nv", "ny", "nyn", "oc", "om", "or", "os", "osa", "pa", "pap", "pcm", "pis", "pl", "ps", "pt", "qu", "quc", "raj", "rhg", "rif", "rm", "rn", "ro", "rof", "ru", "rw", "rwk", "sa", "sah", "saq", "sat", "sbp", "sc", "scn", "sd", "sdh", "se", "seh", "ses", "sg", "shi", "shn", "si", "sid", "skr", "sl", "sma", "smj", "smn", "sms", "sn", "so", "sq", "sr", "ss", "ssy", "st", "su", "sv", "sw", "syr", "szl", "ta", "te", "teo", "tg", "th", "ti", "tig", "tk", "tn", "to", "tok", "tpi", "tr", "trv", "trw", "ts", "tt", "twq", "tyv", "tzm", "ug", "ur", "vai", "ve", "vec", "vi", "vmw", "vo", "vun", "wa", "wal", "wbp", "wo", "xh", "xnr", "xog", "yav", "yi", "yo", "yrl", "za", "zgh", "zu":

--- a/internal/gen/cldr.go.tmpl
+++ b/internal/gen/cldr.go.tmpl
@@ -20,6 +20,8 @@ var calendarMonthNames = [...]calendarMonths{
 {{- end }}
 }
 
+// monthIndexes contains indexes of months names, each calendar has 6 indexes
+// for all variations of "width" and "context".
 type monthIndexes [18]int16
 
 var monthLookup = map[string]monthIndexes{
@@ -28,19 +30,10 @@ var monthLookup = map[string]monthIndexes{
 {{- end }}
 }
 
-func fmtMonth(locale, calendar, context, width string) func(int, string) string {
+func fmtMonth(locale string, calendar calendarType, context, width string) func(int, string) string {
   indexes := monthLookup[locale]
 
-  var i int
-
-  switch calendar {
-  case "gregorian": // noop
-    // "gregorian" calendar index is 0
-  case "buddhist":
-    i = 6 // 1*3*2
-  case "persian":
-    i = 12 // 2*3*2
-  }
+  i := calendar*6
 
   // "abbreviated" width index is 0
   switch width {
@@ -102,14 +95,14 @@ func defaultNumberingSystem(locale language.Tag) numberingSystem {
   }
 }
 
-func defaultCalendar(locale language.Tag) string {
+func defaultCalendar(locale language.Tag) calendarType {
   switch v, _ := locale.Region(); v.String() {
   default:
-    return "gregorian"
+    return calendarTypeGregorian
 {{- range $v := .CalendarPreferences }}
   {{- if ne (index $v.Calendars 0) "gregorian" }}
   case "{{ join $v.Regions "\", \"" }}":
-    return "{{ index $v.Calendars 0 }}"
+    return calendarType{{ title (index $v.Calendars 0) }}
   {{- end }}
 {{- end }}
   }

--- a/intl.go
+++ b/intl.go
@@ -30,6 +30,15 @@ import (
 	"golang.org/x/text/language"
 )
 
+type calendarType int
+
+const (
+	calendarTypeGregorian calendarType = iota
+	calendarTypeBuddhist
+	calendarTypePersian
+	calendarTypeIslamicUmalqura
+)
+
 // Year is year option for [Options].
 type Year byte
 
@@ -277,10 +286,8 @@ func (d digits) Sprint(s string) string {
 // DateTimeFormat encapsulates the configuration and functionality for
 // formatting dates and times according to specific locales and options.
 type DateTimeFormat struct {
-	fmt      dateTimeFormatter
-	locale   language.Tag
-	calendar string
-	options  Options
+	fmt     dateTimeFormatter
+	options Options
 }
 
 // NewDateTimeFormat creates a new [DateTimeFormat] instance for the specified locale and options.
@@ -304,14 +311,14 @@ func NewDateTimeFormat(locale language.Tag, options Options) *DateTimeFormat {
 			fmtDay:   fmtDayGregorian(locale, d),
 			digits:   d,
 		}
-	case "persian":
+	case calendarTypePersian:
 		fmt = &persianDateTimeFormat{
 			fmtYear:  fmtYearPersian(locale),
 			fmtMonth: fmtMonthPersian(locale, d),
 			fmtDay:   fmtDayPersian(locale, d),
 			digits:   d,
 		}
-	case "buddhist":
+	case calendarTypeBuddhist:
 		fmt = &buddhistDateTimeFormat{
 			fmtYear:  fmtYearBuddhist(locale),
 			fmtMonth: fmtMonthBuddhist(locale, d),
@@ -321,10 +328,8 @@ func NewDateTimeFormat(locale language.Tag, options Options) *DateTimeFormat {
 	}
 
 	return &DateTimeFormat{
-		locale:   locale,
-		options:  options,
-		calendar: defaultCalendar(locale),
-		fmt:      fmt,
+		options: options,
+		fmt:     fmt,
 	}
 }
 


### PR DESCRIPTION
```console
$ benchstat a.txt b.txt
goos: darwin
goarch: arm64
pkg: go.expect.digital/intl
cpu: Apple M2 Max
                         │    a.txt    │                b.txt                │
                         │   sec/op    │   sec/op     vs base                │
NewDateTime/fa-IR-12       231.0n ± 2%   207.9n ± 2%  -10.00% (p=0.000 n=10)
NewDateTime/lv-LV-12       295.9n ± 1%   276.8n ± 1%   -6.45% (p=0.000 n=10)
NewDateTime/dz-BT-12       299.3n ± 1%   281.1n ± 1%   -6.10% (p=0.000 n=10)
DateTime_Format/fa-IR-12   828.7n ± 0%   824.6n ± 0%   -0.49% (p=0.022 n=10)
DateTime_Format/lv-LV-12   190.1n ± 1%   188.3n ± 0%   -0.97% (p=0.000 n=10)
DateTime_Format/dz-BT-12   473.9n ± 1%   468.3n ± 2%   -1.18% (p=0.005 n=10)
geomean                    339.4n        324.9n        -4.27%

                         │   a.txt    │                b.txt                 │
                         │    B/op    │    B/op     vs base                  │
NewDateTime/fa-IR-12       309.0 ± 0%   269.0 ± 0%  -12.94% (p=0.000 n=10)
NewDateTime/lv-LV-12       277.0 ± 0%   237.0 ± 0%  -14.44% (p=0.000 n=10)
NewDateTime/dz-BT-12       277.0 ± 0%   237.0 ± 0%  -14.44% (p=0.000 n=10)
DateTime_Format/fa-IR-12   104.0 ± 0%   104.0 ± 0%        ~ (p=1.000 n=10) ¹
DateTime_Format/lv-LV-12   24.00 ± 0%   24.00 ± 0%        ~ (p=1.000 n=10) ¹
DateTime_Format/dz-BT-12   144.0 ± 0%   144.0 ± 0%        ~ (p=1.000 n=10) ¹
geomean                    142.9        132.6        -7.23%
¹ all samples are equal

                         │   a.txt    │                b.txt                │
                         │ allocs/op  │ allocs/op   vs base                 │
NewDateTime/fa-IR-12       5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
NewDateTime/lv-LV-12       6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=10) ¹
NewDateTime/dz-BT-12       6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=10) ¹
DateTime_Format/fa-IR-12   23.00 ± 0%   23.00 ± 0%       ~ (p=1.000 n=10) ¹
DateTime_Format/lv-LV-12   4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=10) ¹
DateTime_Format/dz-BT-12   24.00 ± 0%   24.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                    8.575        8.575       +0.00%
¹ all samples are equal
```