### PR TITLE
TIDY fmt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+cldr.go linguist-generated=false

--- a/cldr.go
+++ b/cldr.go
@@ -1699,6 +1699,17 @@ func fmtMonthName(locale string, calendar calendarType, context, width string) f
 	}
 }
 
+// fmtDay formats day as numeric. The assumption is that f is "2" or "02".
+func fmtDay(digits digits) func(d int, f string) string {
+	return func(d int, f string) string {
+		if f == "02" && d <= 9 {
+			return digits.Sprint("0" + strconv.Itoa(d))
+		}
+
+		return digits.Sprint(strconv.Itoa(d))
+	}
+}
+
 type numberingSystem int
 
 const (
@@ -1860,13 +1871,7 @@ func fmtMonthBuddhist(locale language.Tag, digits digits) func(month int, format
 func fmtDayBuddhist(locale language.Tag, digits digits) func(day int, format string) string {
 	lang, _ := locale.Base()
 
-	fmt := func(d int, f string) string {
-		if f == "02" && d <= 9 {
-			return digits.Sprint("0" + strconv.Itoa(d))
-		}
-
-		return digits.Sprint(strconv.Itoa(d))
-	}
+	fmt := fmtDay(digits)
 
 	switch lang.String() {
 	default:
@@ -1919,13 +1924,7 @@ func fmtMonthGregorian(locale language.Tag, digits digits) func(month int, forma
 func fmtDayGregorian(locale language.Tag, digits digits) func(day int, format string) string {
 	lang, _ := locale.Base()
 
-	fmt := func(d int, f string) string {
-		if f == "02" && d <= 9 {
-			return digits.Sprint("0" + strconv.Itoa(d))
-		}
-
-		return digits.Sprint(strconv.Itoa(d))
-	}
+	fmt := fmtDay(digits)
 
 	switch lang.String() {
 	default:
@@ -1957,13 +1956,7 @@ func fmtMonthPersian(_ language.Tag, digits digits) func(month int, format strin
 }
 
 func fmtDayPersian(_ language.Tag, digits digits) func(day int, format string) string {
-	fmt := func(d int, f string) string {
-		if f == "02" && d <= 9 {
-			return digits.Sprint("0" + strconv.Itoa(d))
-		}
-
-		return digits.Sprint(strconv.Itoa(d))
-	}
+	fmt := fmtDay(digits)
 
 	return fmt
 }

--- a/cldr.go
+++ b/cldr.go
@@ -1649,9 +1649,9 @@ func fmtYear(digits digits) func(y int, f string) string {
 
 		// ptime.Time.Format is very slow. Make it fast!
 		if f == "06" {
-			switch len(year) {
+			switch n := len(year); n {
 			default:
-				year = year[len(year)-2:]
+				year = year[n-2:]
 			case 1:
 				year = "0" + year
 			case 0, 2: // noop, isSliceInBounds()

--- a/cldr.go
+++ b/cldr.go
@@ -1642,7 +1642,39 @@ var monthLookup = map[string]monthIndexes{
 	"zu-ZA":          {749, 749, 751, 751, 750, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 }
 
-func fmtMonth(locale string, calendar calendarType, context, width string) func(int, string) string {
+// fmtYear formats year as numeric. The assumption is that f is "06" or "2006".
+func fmtYear(digits digits) func(y int, f string) string {
+	return func(y int, f string) string {
+		year := strconv.Itoa(y)
+
+		// ptime.Time.Format is very slow. Make it fast!
+		if f == "06" {
+			switch len(year) {
+			default:
+				year = year[len(year)-2:]
+			case 1:
+				year = "0" + year
+			case 0, 2: // noop, isSliceInBounds()
+			}
+		}
+
+		return digits.Sprint(year)
+	}
+}
+
+// fmtMonth formats month as numeric. The assumption is that f is "1" or "01".
+func fmtMonth(digits digits) func(m int, f string) string {
+	return func(m int, f string) string {
+		if f == "01" && m <= 9 {
+			return digits.Sprint("0" + strconv.Itoa(m))
+		}
+
+		return digits.Sprint(strconv.Itoa(m))
+	}
+}
+
+// fmtMonthName formats month as name.
+func fmtMonthName(locale string, calendar calendarType, context, width string) func(int, string) string {
 	indexes := monthLookup[locale]
 
 	i := calendar * 6
@@ -1815,21 +1847,13 @@ func fmtYearBuddhist(locale language.Tag) func(string) string {
 func fmtMonthBuddhist(locale language.Tag, digits digits) func(month int, format string) string {
 	lang, _ := locale.Base()
 
-	fmt := func(m int, f string) string {
-		if f == "01" && m <= 9 {
-			return digits.Sprint("0" + strconv.Itoa(m))
-		}
-
-		return digits.Sprint(strconv.Itoa(m))
-	}
-
 	switch lang.String() {
 	default:
-		return fmt
+		return fmtMonth(digits)
 	case "vi":
-		return func(m int, f string) string { return "tháng " + fmt(m, f) }
+		return func(m int, f string) string { return "tháng " + fmtMonth(digits)(m, f) }
 	case "zh":
-		return func(m int, f string) string { return fmt(m, f) + "月" }
+		return func(m int, f string) string { return fmtMonth(digits)(m, f) + "月" }
 	}
 }
 
@@ -1874,29 +1898,21 @@ func fmtYearGregorian(locale language.Tag) func(string) string {
 func fmtMonthGregorian(locale language.Tag, digits digits) func(month int, format string) string {
 	lang, _ := locale.Base()
 
-	fmt := func(m int, f string) string {
-		if f == "01" && m <= 9 {
-			return digits.Sprint("0" + strconv.Itoa(m))
-		}
-
-		return digits.Sprint(strconv.Itoa(m))
-	}
-
 	switch lang.String() {
 	default:
-		return fmt
+		return fmtMonth(digits)
 	case "wae":
-		return fmtMonth(locale.String(), calendarTypeGregorian, "stand-alone", "abbreviated")
+		return fmtMonthName(locale.String(), calendarTypeGregorian, "stand-alone", "abbreviated")
 	case "mn":
-		return fmtMonth(locale.String(), calendarTypeGregorian, "stand-alone", "narrow")
+		return fmtMonthName(locale.String(), calendarTypeGregorian, "stand-alone", "narrow")
 	case "br", "fo", "ga", "lt", "uk", "uz":
-		return func(m int, f string) string { return fmt(m, "01") }
+		return func(m int, f string) string { return fmtMonth(digits)(m, "01") }
 	case "hr", "nb", "nn", "no", "sk":
-		return func(m int, f string) string { return fmt(m, f) + "." }
+		return func(m int, f string) string { return fmtMonth(digits)(m, f) + "." }
 	case "ja", "yue", "zh":
-		return func(m int, f string) string { return fmt(m, f) + "月" }
+		return func(m int, f string) string { return fmtMonth(digits)(m, f) + "月" }
 	case "ko":
-		return func(m int, f string) string { return fmt(m, f) + "월" }
+		return func(m int, f string) string { return fmtMonth(digits)(m, f) + "월" }
 	}
 }
 
@@ -1937,15 +1953,7 @@ func fmtYearPersian(locale language.Tag) func(string) string {
 }
 
 func fmtMonthPersian(_ language.Tag, digits digits) func(month int, format string) string {
-	fmt := func(m int, f string) string {
-		if f == "01" && m <= 9 {
-			return digits.Sprint("0" + strconv.Itoa(m))
-		}
-
-		return digits.Sprint(strconv.Itoa(m))
-	}
-
-	return fmt
+	return fmtMonth(digits)
 }
 
 func fmtDayPersian(_ language.Tag, digits digits) func(day int, format string) string {
@@ -1973,7 +1981,7 @@ func (f *gregorianDateTimeFormat) SetTime(v time.Time) {
 }
 
 func (f *gregorianDateTimeFormat) Year(format string) string {
-	return f.fmtYear(f.digits.Sprint(f.time.Format(format)))
+	return f.fmtYear(fmtYear(f.digits)(f.time.Year(), format))
 }
 
 func (f *gregorianDateTimeFormat) Month(format string) string {
@@ -1998,20 +2006,7 @@ func (f *persianDateTimeFormat) SetTime(v time.Time) {
 
 // Year returns formatted year (only "06" and "2006" is supported).
 func (f *persianDateTimeFormat) Year(format string) string {
-	year := strconv.Itoa(f.time.Year())
-
-	// ptime.Time.Format is very slow. Make it fast!
-	if format == "06" {
-		switch len(year) {
-		default:
-			year = year[len(year)-2:]
-		case 1:
-			year = "0" + year
-		case 0, 2: // noop, isSliceInBounds()
-		}
-	}
-
-	return f.fmtYear(f.digits.Sprint(year))
+	return f.fmtYear(fmtYear(f.digits)(f.time.Year(), format))
 }
 
 func (f *persianDateTimeFormat) Month(format string) string {
@@ -2035,20 +2030,7 @@ func (f *buddhistDateTimeFormat) SetTime(v time.Time) {
 }
 
 func (f *buddhistDateTimeFormat) Year(format string) string {
-	year := strconv.Itoa(f.time.Year())
-
-	// ptime.Time.Format is very slow. Make it fast!
-	if format == "06" {
-		switch len(year) {
-		default:
-			year = year[len(year)-2:]
-		case 1:
-			year = "0" + year
-		case 0, 2: // noop, isSliceInBounds()
-		}
-	}
-
-	return f.fmtYear(f.digits.Sprint(year))
+	return f.fmtYear(fmtYear(f.digits)(f.time.Year(), format))
 }
 
 func (f *buddhistDateTimeFormat) Month(format string) string {

--- a/cldr.go
+++ b/cldr.go
@@ -1862,9 +1862,11 @@ func fmtMonthBuddhist(locale language.Tag, digits digits) func(month int, format
 	default:
 		return fmtMonth(digits)
 	case "vi":
-		return func(m int, f string) string { return "tháng " + fmtMonth(digits)(m, f) }
+		fmt := fmtMonth(digits)
+		return func(m int, f string) string { return "tháng " + fmt(m, f) }
 	case "zh":
-		return func(m int, f string) string { return fmtMonth(digits)(m, f) + "月" }
+		fmt := fmtMonth(digits)
+		return func(m int, f string) string { return fmt(m, f) + "月" }
 	}
 }
 
@@ -1906,18 +1908,22 @@ func fmtMonthGregorian(locale language.Tag, digits digits) func(month int, forma
 	switch lang.String() {
 	default:
 		return fmtMonth(digits)
+	case "br", "fo", "ga", "lt", "uk", "uz":
+		fmt := fmtMonth(digits)
+		return func(m int, f string) string { return fmt(m, "01") }
+	case "hr", "nb", "nn", "no", "sk":
+		fmt := fmtMonth(digits)
+		return func(m int, f string) string { return fmt(m, f) + "." }
+	case "ja", "yue", "zh":
+		fmt := fmtMonth(digits)
+		return func(m int, f string) string { return fmt(m, f) + "月" }
+	case "ko":
+		fmt := fmtMonth(digits)
+		return func(m int, f string) string { return fmt(m, f) + "월" }
 	case "wae":
 		return fmtMonthName(locale.String(), calendarTypeGregorian, "stand-alone", "abbreviated")
 	case "mn":
 		return fmtMonthName(locale.String(), calendarTypeGregorian, "stand-alone", "narrow")
-	case "br", "fo", "ga", "lt", "uk", "uz":
-		return func(m int, f string) string { return fmtMonth(digits)(m, "01") }
-	case "hr", "nb", "nn", "no", "sk":
-		return func(m int, f string) string { return fmtMonth(digits)(m, f) + "." }
-	case "ja", "yue", "zh":
-		return func(m int, f string) string { return fmtMonth(digits)(m, f) + "月" }
-	case "ko":
-		return func(m int, f string) string { return fmtMonth(digits)(m, f) + "월" }
 	}
 }
 

--- a/cldr.go
+++ b/cldr.go
@@ -1647,7 +1647,6 @@ func fmtYear(digits digits) func(y int, f string) string {
 	return func(y int, f string) string {
 		year := strconv.Itoa(y)
 
-		// ptime.Time.Format is very slow. Make it fast!
 		if f == "06" {
 			switch n := len(year); n {
 			default:

--- a/internal/gen/cldr.go.tmpl
+++ b/internal/gen/cldr.go.tmpl
@@ -87,6 +87,17 @@ func fmtMonthName(locale string, calendar calendarType, context, width string) f
   }
 }
 
+// fmtDay formats day as numeric. The assumption is that f is "2" or "02".
+func fmtDay(digits digits) func(d int, f string) string {
+	return func(d int, f string) string {
+		if f == "02" && d <= 9 {
+			return digits.Sprint("0" + strconv.Itoa(d))
+		}
+
+		return digits.Sprint(strconv.Itoa(d))
+	}
+}
+
 type numberingSystem int
 
 const (
@@ -180,13 +191,7 @@ func fmtDay{{ title $calendarType }}(locale language.Tag, digits digits) func(da
 {{ else }}
 func fmtDay{{ title $calendarType }}(_ language.Tag, digits digits) func(day int, format string) string {
 {{ end }}
-  fmt := func(d int, f string) string {
-    if f == "02" && d <= 9 {
-      return digits.Sprint("0"+strconv.Itoa(d))
-    }
-
-    return digits.Sprint(strconv.Itoa(d))
-  }
+  fmt := fmtDay(digits)
 {{ if eq (len $formats.D.Fmt) 0 }}
   return fmt
 {{ else }}

--- a/internal/gen/cldr.go.tmpl
+++ b/internal/gen/cldr.go.tmpl
@@ -37,9 +37,9 @@ func fmtYear(digits digits) func (y int, f string) string {
 
 		// ptime.Time.Format is very slow. Make it fast!
 		if f == "06" {
-			switch len(year) {
+			switch n := len(year); n {
 			default:
-				year = year[len(year)-2:]
+				year = year[n-2:]
 			case 1:
 				year = "0" + year
 			case 0, 2: // noop, isSliceInBounds()

--- a/internal/gen/cldr.go.tmpl
+++ b/internal/gen/cldr.go.tmpl
@@ -30,7 +30,39 @@ var monthLookup = map[string]monthIndexes{
 {{- end }}
 }
 
-func fmtMonth(locale string, calendar calendarType, context, width string) func(int, string) string {
+// fmtYear formats year as numeric. The assumption is that f is "06" or "2006".
+func fmtYear(digits digits) func (y int, f string) string {
+	return func(y int, f string) string {
+		year := strconv.Itoa(y)
+
+		// ptime.Time.Format is very slow. Make it fast!
+		if f == "06" {
+			switch len(year) {
+			default:
+				year = year[len(year)-2:]
+			case 1:
+				year = "0" + year
+			case 0, 2: // noop, isSliceInBounds()
+			}
+		}
+
+		return digits.Sprint(year)
+	}
+}
+
+// fmtMonth formats month as numeric. The assumption is that f is "1" or "01".
+func fmtMonth(digits digits) func (m int, f string) string {
+	return func(m int, f string) string {
+		if f == "01" && m <= 9 {
+			return digits.Sprint("0" + strconv.Itoa(m))
+		}
+
+		return digits.Sprint(strconv.Itoa(m))
+	}
+}
+
+// fmtMonthName formats month as name.
+func fmtMonthName(locale string, calendar calendarType, context, width string) func(int, string) string {
   indexes := monthLookup[locale]
 
   i := calendar*6
@@ -128,20 +160,12 @@ func fmtMonth{{ title $calendarType }}(locale language.Tag, digits digits) func(
 {{ else }}
 func fmtMonth{{ title $calendarType }}(_ language.Tag, digits digits) func(month int, format string) string {
 {{ end }}
-  fmt := func(m int, f string) string {
-    if f == "01" && m <= 9 {
-      return digits.Sprint("0"+strconv.Itoa(m))
-    }
-
-    return digits.Sprint(strconv.Itoa(m))
-  }
-
 {{ if eq (len $formats.M.Fmt) 0 }}
-  return fmt
+  return fmtMonth(digits)
 {{ else }}
   switch lang.String() {
   default:
-    return fmt
+    return fmtMonth(digits)
   {{- range $fmt, $languages := $formats.M.Fmt }}
   case "{{ join $languages "\", \"" }}":
     return {{ $fmt }}
@@ -163,8 +187,6 @@ func fmtDay{{ title $calendarType }}(_ language.Tag, digits digits) func(day int
 
     return digits.Sprint(strconv.Itoa(d))
   }
-
-
 {{ if eq (len $formats.D.Fmt) 0 }}
   return fmt
 {{ else }}
@@ -193,7 +215,7 @@ func (f *gregorianDateTimeFormat) SetTime(v time.Time) {
 }
 
 func (f *gregorianDateTimeFormat) Year(format string) string {
-  return f.fmtYear(f.digits.Sprint(f.time.Format(format)))
+  return f.fmtYear(fmtYear(f.digits)(f.time.Year(), format))
 }
 
 func (f *gregorianDateTimeFormat) Month(format string) string {
@@ -218,20 +240,7 @@ func (f *persianDateTimeFormat) SetTime(v time.Time) {
 
 // Year returns formatted year (only "06" and "2006" is supported).
 func (f *persianDateTimeFormat) Year(format string) string {
-  year := strconv.Itoa(f.time.Year())
-
-  // ptime.Time.Format is very slow. Make it fast!
-  if format == "06" {
-    switch len(year) {
-    default:
-      year = year[len(year)-2:]
-    case 1:
-      year = "0" + year
-    case 0, 2: // noop, isSliceInBounds()
-    }
-  }
-
-  return f.fmtYear(f.digits.Sprint(year))
+  return f.fmtYear(fmtYear(f.digits)(f.time.Year(), format))
 }
 
 func (f *persianDateTimeFormat) Month(format string) string {
@@ -255,20 +264,7 @@ func (f *buddhistDateTimeFormat) SetTime(v time.Time) {
 }
 
 func (f *buddhistDateTimeFormat) Year(format string) string {
-  year := strconv.Itoa(f.time.Year())
-
-  // ptime.Time.Format is very slow. Make it fast!
-  if format == "06" {
-    switch len(year) {
-    default:
-      year = year[len(year)-2:]
-    case 1:
-      year = "0" + year
-    case 0, 2: // noop, isSliceInBounds()
-    }
-  }
-
-  return f.fmtYear(f.digits.Sprint(year))
+  return f.fmtYear(fmtYear(f.digits)(f.time.Year(), format))
 }
 
 func (f *buddhistDateTimeFormat) Month(format string) string {

--- a/internal/gen/cldr.go.tmpl
+++ b/internal/gen/cldr.go.tmpl
@@ -179,7 +179,7 @@ func fmtMonth{{ title $calendarType }}(_ language.Tag, digits digits) func(month
     return fmtMonth(digits)
   {{- range $fmt, $languages := $formats.M.Fmt }}
   case "{{ join $languages "\", \"" }}":
-    return {{ $fmt }}
+    {{ $fmt }}
   {{- end }}
   }
 {{ end }} {{/* $formats.M.Fmt > 1*/}}

--- a/internal/gen/cldr.go.tmpl
+++ b/internal/gen/cldr.go.tmpl
@@ -35,7 +35,6 @@ func fmtYear(digits digits) func (y int, f string) string {
 	return func(y int, f string) string {
 		year := strconv.Itoa(y)
 
-		// ptime.Time.Format is very slow. Make it fast!
 		if f == "06" {
 			switch n := len(year); n {
 			default:

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -499,27 +499,27 @@ func (g *Generator) addDateFormatItem(
 
 			switch v.value {
 			default:
-				sb.WriteString("fmt(m, f)")
+				sb.WriteString("fmtMonth(digits)(m, f)")
 			case "LL", "MM":
-				sb.WriteString(`fmt(m, "01")`)
+				sb.WriteString(`fmtMonth(digits)(m, "01")`)
 			case "LLL":
-				sb.WriteString(f(`fmtMonth(locale.String(), calendarType%s, "stand-alone", "abbreviated")`))
+				sb.WriteString(f(`fmtMonthName(locale.String(), calendarType%s, "stand-alone", "abbreviated")`))
 			case "MMM":
-				sb.WriteString(f(`fmtMonth(locale.String(), calendarType%s, "format", "abbreviated")`))
+				sb.WriteString(f(`fmtMonthName(locale.String(), calendarType%s, "format", "abbreviated")`))
 			case "LLLL":
-				sb.WriteString(f(`fmtMonth(locale.String(), calendarType%s, "stand-alone", "wide")`))
+				sb.WriteString(f(`fmtMonthName(locale.String(), calendarType%s, "stand-alone", "wide")`))
 			case "MMMM":
-				sb.WriteString(f(`fmtMonth(locale.String(), calendarType%s, "format", "wide")`))
+				sb.WriteString(f(`fmtMonthName(locale.String(), calendarType%s, "format", "wide")`))
 			case "LLLLL":
-				sb.WriteString(f(`fmtMonth(locale.String(), calendarType%s, "stand-alone", "narrow")`))
+				sb.WriteString(f(`fmtMonthName(locale.String(), calendarType%s, "stand-alone", "narrow")`))
 			case "MMMMM":
-				sb.WriteString(f(`fmtMonth(locale.String(), calendarType%s, "format", "narrow")`))
+				sb.WriteString(f(`fmtMonthName(locale.String(), calendarType%s, "format", "narrow")`))
 			}
 		}
 
 		s := sb.String()
 
-		if !strings.Contains(s, "fmtMonth") {
+		if !strings.Contains(s, "fmtMonthName") {
 			s = `func(m int, f string) string { return ` + s + ` }`
 		}
 

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -499,9 +499,9 @@ func (g *Generator) addDateFormatItem(
 
 			switch v.value {
 			default:
-				sb.WriteString("fmtMonth(digits)(m, f)")
+				sb.WriteString("fmt(m, f)")
 			case "LL", "MM":
-				sb.WriteString(`fmtMonth(digits)(m, "01")`)
+				sb.WriteString(`fmt(m, "01")`)
 			case "LLL":
 				sb.WriteString(f(`fmtMonthName(locale.String(), calendarType%s, "stand-alone", "abbreviated")`))
 			case "MMM":
@@ -519,8 +519,10 @@ func (g *Generator) addDateFormatItem(
 
 		s := sb.String()
 
-		if !strings.Contains(s, "fmtMonthName") {
-			s = `func(m int, f string) string { return ` + s + ` }`
+		if strings.Contains(s, "fmtMonthName") {
+			s = "return " + s
+		} else {
+			s = `fmt := fmtMonth(digits); return func(m int, f string) string { return ` + s + ` }`
 		}
 
 		dateTimeFormats.M.Fmt[s] = append(dateTimeFormats.M.Fmt[s], locale)


### PR DESCRIPTION
```console
$ benchstat a.txt b.txt
goos: darwin
goarch: arm64
pkg: go.expect.digital/intl
cpu: Apple M2 Max
                         │    a.txt    │               b.txt                │
                         │   sec/op    │   sec/op     vs base               │
NewDateTime/fa-IR-12       207.5n ± 1%   207.8n ± 1%       ~ (p=0.382 n=10)
NewDateTime/lv-LV-12       257.4n ± 2%   257.1n ± 1%       ~ (p=0.516 n=10)
NewDateTime/dz-BT-12       260.0n ± 1%   261.4n ± 0%       ~ (p=0.271 n=10)
DateTime_Format/fa-IR-12   835.8n ± 1%   844.9n ± 1%  +1.08% (p=0.002 n=10)
DateTime_Format/lv-LV-12   190.2n ± 1%   173.3n ± 1%  -8.86% (p=0.000 n=10)
DateTime_Format/dz-BT-12   475.0n ± 1%   454.5n ± 0%  -4.33% (p=0.000 n=10)
geomean                    318.7n        312.4n       -1.98%

                         │   a.txt    │                b.txt                 │
                         │    B/op    │    B/op     vs base                  │
NewDateTime/fa-IR-12       269.0 ± 0%   269.0 ± 0%        ~ (p=1.000 n=10) ¹
NewDateTime/lv-LV-12       221.0 ± 0%   221.0 ± 0%        ~ (p=1.000 n=10) ¹
NewDateTime/dz-BT-12       221.0 ± 0%   221.0 ± 0%        ~ (p=1.000 n=10) ¹
DateTime_Format/fa-IR-12   104.0 ± 0%   104.0 ± 0%        ~ (p=1.000 n=10) ¹
DateTime_Format/lv-LV-12   24.00 ± 0%   32.00 ± 0%  +33.33% (p=0.000 n=10)
DateTime_Format/dz-BT-12   144.0 ± 0%   144.0 ± 0%        ~ (p=1.000 n=10) ¹
geomean                    129.5        135.9        +4.91%
¹ all samples are equal

                         │   a.txt    │                b.txt                │
                         │ allocs/op  │ allocs/op   vs base                 │
NewDateTime/fa-IR-12       5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
NewDateTime/lv-LV-12       5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
NewDateTime/dz-BT-12       5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
DateTime_Format/fa-IR-12   23.00 ± 0%   23.00 ± 0%       ~ (p=1.000 n=10) ¹
DateTime_Format/lv-LV-12   4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=10) ¹
DateTime_Format/dz-BT-12   24.00 ± 0%   24.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                    8.069        8.069       +0.00%
¹ all samples are equal
```