### PR TITLE
33 - fix yue locales

### DIFF
--- a/fmt_ym.go
+++ b/fmt_ym.go
@@ -95,7 +95,19 @@ func fmtYearMonthGregorian(locale language.Tag, digits digits, opts Options) fun
 		return func(y int, m time.Month) string {
 			return fmtMonth(m, MonthNumeric) + "/" + fmtYear(y, opts.Year)
 		}
-	case eu, ja, yue:
+	case yue:
+		if script == hans {
+			// year=numeric,month=numeric,out=2024年1月
+			// year=numeric,month=2-digit,out=2024年1月
+			// year=2-digit,month=numeric,out=24年1月
+			// year=2-digit,month=2-digit,out=24年1月
+			return func(y int, m time.Month) string {
+				return fmtYear(y, opts.Year) + "年" + fmtMonth(m, MonthNumeric) + "月"
+			}
+		}
+
+		fallthrough
+	case eu, ja:
 		return func(y int, m time.Month) string {
 			return fmtYear(y, opts.Year) + "/" + fmtMonth(m, opts.Month)
 		}

--- a/intl_test.go
+++ b/intl_test.go
@@ -266,9 +266,6 @@ func skipTest(locale language.Tag) string {
 		"uz-Cyrl-UZ":  "regional formatting",
 		"vai-Latn":    "regional formatting",
 		"vai-Latn-LR": "regional formatting",
-		"yue-Hans":    "regional formatting",
-		"yue-Hans-CN": "regional formatting",
-		"yue-Hant-HK": "regional formatting",
 	}[locale.String()]
 }
 


### PR DESCRIPTION
```console
$ gsa cmd.a cmd.b
┌───────────────────────────────────────────────────────────────────┐
│ Diff between cmd.a and cmd.b                                      │
├─────────┬──────────────────────────┬──────────┬──────────┬────────┤
│ PERCENT │ NAME                     │ OLD SIZE │ NEW SIZE │ DIFF   │
├─────────┼──────────────────────────┼──────────┼──────────┼────────┤
│ +0.16%  │ go.expect.digital/intl   │ 294 kB   │ 294 kB   │ +481 B │
├─────────┼──────────────────────────┼──────────┼──────────┼────────┤
│ +0.08%  │ __zdebug_info __DWARF    │ 335 kB   │ 335 kB   │ +274 B │
│ +0.03%  │ __zdebug_line __DWARF    │ 146 kB   │ 146 kB   │ +43 B  │
│ +0.07%  │ __zdebug_frame __DWARF   │ 34 kB    │ 34 kB    │ +23 B  │
│ +0.01%  │ __zdebug_loc __DWARF     │ 160 kB   │ 160 kB   │ +13 B  │
│ -0.00%  │ __zdebug_ranges __DWARF  │ 47 kB    │ 47 kB    │ -2 B   │
│ -0.02%  │ __gopclntab __DATA_CONST │ 94 kB    │ 94 kB    │ -17 B  │
├─────────┼──────────────────────────┼──────────┼──────────┼────────┤
│ +0.00%  │ cmd.a                    │ 3.0 MB   │ 3.0 MB   │ +80 B  │
│         │ cmd.b                    │          │          │        │
└─────────┴──────────────────────────┴──────────┴──────────┴────────┘
```