### PR TITLE
55 - replace fmt functions with state

### DIFF
--- a/fmt_d.go
+++ b/fmt_d.go
@@ -5,26 +5,28 @@ import "golang.org/x/text/language"
 func fmtDayGregorian(locale language.Tag, digits digits) func(d int, opt Day) string {
 	fmt := fmtDay(digits)
 
+	suffix := ""
+
 	switch lang, _ := locale.Base(); lang {
-	default:
-		return fmt
 	case bs:
 		if script, _ := locale.Script(); script == cyrl {
 			return fmt
 		}
 
-		return func(d int, opt Day) string { return fmt(d, opt) + "." }
+		suffix = "."
 	case cs, da, dsb, fo, hr, hsb, ie, nb, nn, no, sk, sl:
-		return func(d int, opt Day) string { return fmt(d, opt) + "." }
+		suffix = "."
 	case ja, yue, zh:
-		return func(d int, opt Day) string { return fmt(d, opt) + "日" }
+		suffix = "日"
 	case ko:
-		return func(d int, opt Day) string { return fmt(d, opt) + "일" }
+		suffix = "일"
 	case lt:
 		return func(d int, _ Day) string { return fmt(d, Day2Digit) }
 	case ii:
-		return func(d int, opt Day) string { return fmt(d, opt) + "ꑍ" }
+		suffix = "ꑍ"
 	}
+
+	return func(d int, opt Day) string { return fmt(d, opt) + suffix }
 }
 
 func fmtDayBuddhist(_ language.Tag, digits digits) func(d int, opt Day) string {

--- a/fmt_gyd.go
+++ b/fmt_gyd.go
@@ -2,13 +2,6 @@ package intl
 
 import "golang.org/x/text/language"
 
-type EraYearDay int
-
-const (
-	eraYearDay EraYearDay = iota
-	eraDayYear
-)
-
 //nolint:cyclop
 func fmtEraYearDayGregorian(locale language.Tag, digits digits, opts Options) func(y, d int) string {
 	lang, script, region := locale.Raw()
@@ -17,6 +10,11 @@ func fmtEraYearDayGregorian(locale language.Tag, digits digits, opts Options) fu
 	fmtYear := fmtYear(digits)
 	fmtDay := fmtDay(digits)
 	dayName := unitName(locale).Day
+
+	const (
+		eraYearDay = iota
+		eraDayYear
+	)
 
 	layout := eraYearDay
 	prefix := ""

--- a/fmt_gym.go
+++ b/fmt_gym.go
@@ -6,15 +6,6 @@ import (
 	"golang.org/x/text/language"
 )
 
-type EraYearMonth int
-
-const (
-	// eraYearMonth includes "era year month" and "year month era".
-	eraYearMonth EraYearMonth = iota
-	// eraMonthYear includes "era month year" and "month year era".
-	eraMonthYear
-)
-
 //nolint:cyclop
 func fmtEraYearMonthGregorian(locale language.Tag, digits digits, opts Options) func(y int, m time.Month) string {
 	lang, script, region := locale.Raw()
@@ -23,6 +14,13 @@ func fmtEraYearMonthGregorian(locale language.Tag, digits digits, opts Options) 
 	layoutYear := fmtYearGregorian(locale)
 	fmtMonth := fmtMonth(digits)
 	monthName := unitName(locale).Month
+
+	const (
+		// eraYearMonth includes "era year month" and "year month era".
+		eraYearMonth = iota
+		// eraMonthYear includes "era month year" and "month year era".
+		eraMonthYear
+	)
 
 	layout := eraMonthYear
 	prefix := ""
@@ -204,6 +202,13 @@ func fmtEraYearMonthPersian(locale language.Tag, digits digits, opts Options) fu
 	fmtYear := fmtYear(digits)
 	layoutYear := fmtYearPersian(locale)
 	fmtMonth := fmtMonth(digits)
+
+	const (
+		// eraYearMonth includes "era year month" and "year month era".
+		eraYearMonth = iota
+		// eraMonthYear includes "era month year" and "month year era".
+		eraMonthYear
+	)
 
 	layout := eraYearMonth
 	prefix := era + " "

--- a/fmt_gymd.go
+++ b/fmt_gymd.go
@@ -6,15 +6,6 @@ import (
 	"golang.org/x/text/language"
 )
 
-type EraYearMonthDay int
-
-const (
-	eraYearMonthDay EraYearMonthDay = iota
-	eraMonthDayYear
-	eraDayMonthYear
-	dayMonthEraYear
-)
-
 //nolint:cyclop,gocognit
 func fmtEraYearMonthDayGregorian(
 	locale language.Tag,
@@ -27,6 +18,13 @@ func fmtEraYearMonthDayGregorian(
 	fmtYear := fmtYear(digits)
 	fmtMonth := fmtMonth(digits)
 	fmtDay := fmtDay(digits)
+
+	const (
+		eraYearMonthDay = iota
+		eraMonthDayYear
+		eraDayMonthYear
+		dayMonthEraYear
+	)
 
 	month, day := Month2Digit, Day2Digit
 	layout := eraYearMonthDay
@@ -298,6 +296,12 @@ func fmtEraYearMonthDayPersian(
 	fmtYear := fmtYear(digits)
 	fmtMonth := fmtMonth(digits)
 	fmtDay := fmtDay(digits)
+
+	const (
+		eraYearMonthDay = iota
+		eraMonthDayYear
+	)
+
 	layout := eraMonthDayYear
 	separator := "/"
 	suffix := " " + era

--- a/fmt_m.go
+++ b/fmt_m.go
@@ -7,26 +7,23 @@ import (
 )
 
 func fmtMonthGregorian(locale language.Tag, digits digits) func(m time.Month, opt Month) string {
+	fmt := fmtMonth(digits)
+	suffix := ""
+
 	switch lang, _ := locale.Base(); lang {
-	default:
-		return fmtMonth(digits)
 	case br, fo, ga, lt, uk, uz:
-		fmt := fmtMonth(digits)
 		return func(m time.Month, _ Month) string { return fmt(m, Month2Digit) }
 	case hr, nb, nn, no, sk:
-		fmt := fmtMonth(digits)
-		return func(m time.Month, opt Month) string { return fmt(m, opt) + "." }
-	case ja, yue, zh:
-		fmt := fmtMonth(digits)
-		return func(m time.Month, opt Month) string { return fmt(m, opt) + "月" }
-	case ko:
-		fmt := fmtMonth(digits)
-		return func(m time.Month, opt Month) string { return fmt(m, opt) + "월" }
+		suffix = "."
+	case ja, yue, zh, ko:
+		suffix = unitName(locale).Month
 	case mn:
 		return fmtMonthName(locale.String(), "stand-alone", "narrow")
 	case wae:
 		return fmtMonthName(locale.String(), "stand-alone", "abbreviated")
 	}
+
+	return func(m time.Month, opt Month) string { return fmt(m, opt) + suffix }
 }
 
 func fmtMonthBuddhist(_ language.Tag, digits digits) func(m time.Month, opt Month) string {

--- a/fmt_y.go
+++ b/fmt_y.go
@@ -3,39 +3,36 @@ package intl
 import "golang.org/x/text/language"
 
 func fmtYearGregorian(locale language.Tag) func(y string) string {
+	var suffix string
+
 	switch lang, _ := locale.Base(); lang {
-	default:
-		return func(y string) string { return y }
 	case bg, mk:
-		return func(y string) string { return y + " г." }
+		suffix = " г."
 	case bs, hr, hu, sr:
-		return func(y string) string { return y + "." }
+		suffix = "."
 	case ja, yue, zh:
-		return func(y string) string { return y + "年" }
+		suffix = "年"
 	case ko:
-		return func(y string) string { return y + "년" }
+		suffix = "년"
 	case lv:
-		return func(y string) string { return y + ". g." }
+		suffix = ". g."
 	}
+
+	return func(y string) string { return y + suffix }
 }
 
 func fmtYearBuddhist(locale language.Tag, era Era) func(y string) string {
-	return func(y string) string { return fmtEra(locale, era) + " " + y }
+	prefix := fmtEra(locale, era) + " "
+	return func(y string) string { return prefix + y }
 }
 
 func fmtYearPersian(locale language.Tag) func(y string) string {
 	lang, _, region := locale.Raw()
+	prefix := ""
 
-	switch lang {
-	case fa:
-		return func(y string) string { return y }
-	case uz:
-		if region == regionAF {
-			return func(y string) string { return y }
-		}
-
-		fallthrough
-	default:
-		return func(y string) string { return fmtEra(locale, EraNarrow) + " " + y }
+	if !(lang == fa || lang == uz && region == regionAF) {
+		prefix = fmtEra(locale, EraNarrow) + " "
 	}
+
+	return func(y string) string { return prefix + y }
 }

--- a/fmt_yd.go
+++ b/fmt_yd.go
@@ -1,6 +1,8 @@
 package intl
 
-import "golang.org/x/text/language"
+import (
+	"golang.org/x/text/language"
+)
 
 func fmtYearDayGregorian(locale language.Tag, digits digits, opts Options) func(y, d int) string {
 	lang, script, _ := locale.Raw()
@@ -8,85 +10,48 @@ func fmtYearDayGregorian(locale language.Tag, digits digits, opts Options) func(
 	fmtYear := fmtYear(digits)
 	fmtDay := fmtDayGregorian(locale, digits)
 
+	const (
+		layoutYearDay = iota
+		layoutDayYear
+	)
+
+	withName := opts.Year != Year2Digit || opts.Day != DayNumeric
+	dayName := unitName(locale).Day
+	layout := layoutYearDay
+	middle := " "
+	suffix := ""
+
+	if withName {
+		middle = " (" + dayName + ": "
+		suffix = ")"
+	}
+
 	switch lang {
 	case bg, mk:
-		if opts.Year == Year2Digit && opts.Day == DayNumeric {
-			return func(y, d int) string {
-				return layoutYear(fmtYear(y, opts.Year)) + " " + fmtDay(d, opts.Day)
-			}
-		}
-
-		dayName := unitName(locale).Day
-
-		return func(y, d int) string {
-			return layoutYear(fmtYear(y, opts.Year)) + " (" + dayName + ": " + fmtDay(d, opts.Day) + ")"
+		if withName {
+			middle = " (" + dayName + ": "
+		} else {
+			middle = " "
 		}
 	case kaa, en, mhn:
-		if opts.Year == Year2Digit && opts.Day == DayNumeric {
-			return func(y, d int) string {
-				return fmtDay(d, opts.Day) + " " + layoutYear(fmtYear(y, opts.Year))
-			}
-		}
-
-		dayName := unitName(locale).Day
-
-		return func(y, d int) string {
-			return layoutYear(fmtYear(y, opts.Year)) + " (" + dayName + ": " + fmtDay(d, opts.Day) + ")"
+		if !withName {
+			layout = layoutDayYear
 		}
 	case hi:
-		if opts.Year == Year2Digit && opts.Day == DayNumeric {
-			if script == latn {
-				return func(y, d int) string {
-					return fmtDay(d, opts.Day) + " " + layoutYear(fmtYear(y, opts.Year))
-				}
-			}
-
-			return func(y, d int) string {
-				return layoutYear(fmtYear(y, opts.Year)) + " " + fmtDay(d, opts.Day)
-			}
-		}
-
-		dayName := unitName(locale).Day
-
-		return func(y, d int) string {
-			return layoutYear(fmtYear(y, opts.Year)) + " (" + dayName + ": " + fmtDay(d, opts.Day) + ")"
-		}
-	case ie:
-		dayName := unitName(locale).Day
-
-		if opts.Year == Year2Digit && opts.Day == DayNumeric {
-			return func(y, d int) string {
-				return layoutYear(fmtYear(y, opts.Year)) + " " + fmtDay(d, opts.Day)
-			}
-		}
-
-		return func(y, d int) string {
-			return layoutYear(fmtYear(y, opts.Year)) + " (" + dayName + ": " + fmtDay(d, opts.Day) + ")"
-		}
-	case ii:
-		if opts.Year == Year2Digit && opts.Day == DayNumeric {
-			return func(y, d int) string {
-				return layoutYear(fmtYear(y, opts.Year)) + " " + fmtDay(d, opts.Day)
-			}
-		}
-
-		dayName := unitName(locale).Day
-
-		return func(y, d int) string {
-			return layoutYear(fmtYear(y, opts.Year)) + " (" + dayName + ": " + fmtDay(d, opts.Day) + ")"
+		if !withName && script == latn {
+			layout = layoutDayYear
 		}
 	}
 
-	if opts.Year == Year2Digit && opts.Day == DayNumeric {
+	if layout == layoutDayYear {
 		return func(y, d int) string {
-			return layoutYear(fmtYear(y, opts.Year)) + " " + fmtDay(d, opts.Day)
+			return fmtDay(d, opts.Day) + middle + layoutYear(fmtYear(y, opts.Year)) + suffix
 		}
 	}
 
-	dayName := unitName(locale).Day
-
+	// layoutYearDay
 	return func(y, d int) string {
-		return layoutYear(fmtYear(y, opts.Year)) + " (" + dayName + ": " + fmtDay(d, opts.Day) + ")"
+		return layoutYear(fmtYear(y, opts.Year)) + middle + fmtDay(d, opts.Day) + suffix
 	}
 }
 
@@ -96,48 +61,22 @@ func fmtYearDayPersian(locale language.Tag, digits digits, opts Options) func(y,
 	fmtYear := fmtYear(digits)
 	fmtDay := fmtDayGregorian(locale, digits)
 
-	switch lang {
-	case fa:
-		if opts.Year == Year2Digit && opts.Day == DayNumeric {
-			return func(y, d int) string {
-				return layoutYear(fmtYear(y, opts.Year)) + " " + fmtDay(d, opts.Day)
-			}
-		}
+	prefix := ""
+	middle := " "
+	suffix := ""
 
+	if opts.Year != Year2Digit || opts.Day != DayNumeric {
 		dayName := unitName(locale).Day
-
-		return func(y, d int) string {
-			return layoutYear(fmtYear(y, opts.Year)) + " (" + dayName + ": " + fmtDay(d, opts.Day) + ")"
-		}
-	case uz:
-		if region != regionAF {
-			break
-		}
-
-		if opts.Year == Year2Digit && opts.Day == DayNumeric {
-			return func(y, d int) string {
-				return layoutYear(fmtYear(y, opts.Year)) + " " + fmtDay(d, opts.Day)
-			}
-		}
-
-		dayName := unitName(locale).Day
-
-		return func(y, d int) string {
-			return layoutYear(fmtYear(y, opts.Year)) + " (" + dayName + ": " + fmtDay(d, opts.Day) + ")"
-		}
+		middle = " (" + dayName + ": "
+		suffix = ")"
 	}
 
-	if opts.Year == Year2Digit && opts.Day == DayNumeric {
-		return func(y, d int) string {
-			return fmtEra(locale, EraNarrow) + " " + layoutYear(fmtYear(y, opts.Year)) + " " + fmtDay(d, opts.Day)
-		}
+	if !(lang == fa || lang == uz && region == regionAF) {
+		prefix = fmtEra(locale, EraNarrow) + " "
 	}
-
-	dayName := unitName(locale).Day
 
 	return func(y, d int) string {
-		return fmtEra(locale, EraNarrow) + " " + layoutYear(fmtYear(y, opts.Year)) +
-			" (" + dayName + ": " + fmtDay(d, opts.Day) + ")"
+		return prefix + layoutYear(fmtYear(y, opts.Year)) + middle + fmtDay(d, opts.Day) + suffix
 	}
 }
 
@@ -146,15 +85,16 @@ func fmtYearDayBuddhist(locale language.Tag, digits digits, opts Options) func(y
 	fmtYear := fmtYear(digits)
 	fmtDay := fmtDayBuddhist(locale, digits)
 
-	if opts.Year == Year2Digit && opts.Day == DayNumeric {
-		return func(y, d int) string {
-			return layoutYear(fmtYear(y, opts.Year)) + " " + fmtDay(d, opts.Day)
-		}
+	middle := " "
+	suffix := ""
+
+	if opts.Year != Year2Digit || opts.Day != DayNumeric {
+		dayName := unitName(locale).Day
+		middle = " (" + dayName + ": "
+		suffix = ")"
 	}
 
-	dayName := unitName(locale).Day
-
 	return func(y, d int) string {
-		return layoutYear(fmtYear(y, opts.Year)) + " (" + dayName + ": " + fmtDay(d, opts.Day) + ")"
+		return layoutYear(fmtYear(y, opts.Year)) + middle + fmtDay(d, opts.Day) + suffix
 	}
 }


### PR DESCRIPTION
```console
$ gsa a b
┌────────────────────────────────────────────────────────────────────┐
│ Diff between a and b                                               │
├─────────┬──────────────────────────┬──────────┬──────────┬─────────┤
│ PERCENT │ NAME                     │ OLD SIZE │ NEW SIZE │ DIFF    │
├─────────┼──────────────────────────┼──────────┼──────────┼─────────┤
│ -1.05%  │ <autogenerated>          │ 27 kB    │ 27 kB    │ -286 B  │
│ -27.19% │ go.expect.digital/intl   │ 462 kB   │ 336 kB   │ -126 kB │
├─────────┼──────────────────────────┼──────────┼──────────┼─────────┤
│ -0.60%  │ __typelink __DATA_CONST  │ 2.0 kB   │ 2.0 kB   │ -12 B   │
│ -0.32%  │ __zdebug_ranges __DWARF  │ 47 kB    │ 47 kB    │ -149 B  │
│ -0.34%  │ __rodata __TEXT          │ 250 kB   │ 249 kB   │ -840 B  │
│ -2.29%  │ __gopclntab __DATA_CONST │ 96 kB    │ 94 kB    │ -2.2 kB │
│ -7.46%  │ __zdebug_frame __DWARF   │ 36 kB    │ 33 kB    │ -2.7 kB │
│ -1.77%  │ __zdebug_line __DWARF    │ 154 kB   │ 151 kB   │ -2.7 kB │
│ -2.62%  │ __rodata __DATA_CONST    │ 278 kB   │ 271 kB   │ -7.3 kB │
│ -6.29%  │ __zdebug_loc __DWARF     │ 178 kB   │ 166 kB   │ -11 kB  │
│ -4.49%  │ __zdebug_info __DWARF    │ 351 kB   │ 335 kB   │ -16 kB  │
├─────────┼──────────────────────────┼──────────┼──────────┼─────────┤
│ -4.98%  │ a                        │ 3.4 MB   │ 3.2 MB   │ -169 kB │
│         │ b                        │          │          │         │
└─────────┴──────────────────────────┴──────────┴──────────┴─────────┘
```