### PR TITLE
61 - change the fmtYear signature

### DIFF
--- a/fmt_gy.go
+++ b/fmt_gy.go
@@ -5,7 +5,7 @@ import "golang.org/x/text/language"
 func fmtEraYearGregorian(locale language.Tag, digits digits, opts Options) func(y int) string {
 	lang, script, region := locale.Raw()
 	era := fmtEra(locale, opts.Era)
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 	layoutYear := fmtYearGregorian(locale)
 
 	prefix := ""
@@ -78,13 +78,13 @@ func fmtEraYearGregorian(locale language.Tag, digits digits, opts Options) func(
 		suffix = ""
 	}
 
-	return func(y int) string { return prefix + layoutYear(year(y, opts.Year)) + suffix }
+	return func(y int) string { return prefix + layoutYear(year(y)) + suffix }
 }
 
 func fmtEraYearPersian(locale language.Tag, digits digits, opts Options) func(y int) string {
 	lang, _ := locale.Base()
 	era := fmtEra(locale, opts.Era)
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 
 	prefix := ""
 	suffix := " " + era
@@ -98,15 +98,15 @@ func fmtEraYearPersian(locale language.Tag, digits digits, opts Options) func(y 
 	}
 
 	return func(y int) string {
-		return prefix + year(y, opts.Year) + suffix
+		return prefix + year(y) + suffix
 	}
 }
 
 func fmtEraYearBuddhist(locale language.Tag, digits digits, opts Options) func(y int) string {
 	era := fmtEra(locale, opts.Era)
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 
 	return func(y int) string {
-		return era + " " + year(y, opts.Year)
+		return era + " " + year(y)
 	}
 }

--- a/fmt_gyd.go
+++ b/fmt_gyd.go
@@ -6,8 +6,8 @@ import "golang.org/x/text/language"
 func fmtEraYearDayGregorian(locale language.Tag, digits digits, opts Options) func(y, d int) string {
 	lang, script, region := locale.Raw()
 	era := fmtEra(locale, opts.Era)
+	year := fmtYear(digits, opts.Year)
 	layoutYear := fmtYearGregorian(locale)
-	year := fmtYear(digits)
 	dayName := unitName(locale).Day
 
 	const (
@@ -120,11 +120,11 @@ func fmtEraYearDayGregorian(locale language.Tag, digits digits, opts Options) fu
 	switch layout {
 	default: // eraYearDay
 		return func(y, d int) string {
-			return prefix + layoutYear(year(y, opts.Year)) + middle + day(d) + suffix
+			return prefix + layoutYear(year(y)) + middle + day(d) + suffix
 		}
 	case eraDayYear:
 		return func(y, d int) string {
-			return prefix + day(d) + middle + layoutYear(year(y, opts.Year)) + suffix
+			return prefix + day(d) + middle + layoutYear(year(y)) + suffix
 		}
 	}
 }
@@ -133,7 +133,7 @@ func fmtEraYearDayPersian(locale language.Tag, digits digits, opts Options) func
 	lang, _ := locale.Base()
 	era := fmtEra(locale, opts.Era)
 	layoutYear := fmtYearGregorian(locale)
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 	dayName := unitName(locale).Day
 
 	prefix := era + " "
@@ -148,19 +148,19 @@ func fmtEraYearDayPersian(locale language.Tag, digits digits, opts Options) func
 	day := fmtDay(digits, opts.Day)
 
 	return func(y, d int) string {
-		return prefix + layoutYear(year(y, opts.Year)) + middle + day(d) + suffix
+		return prefix + layoutYear(year(y)) + middle + day(d) + suffix
 	}
 }
 
 func fmtEraYearDayBuddhist(locale language.Tag, digits digits, opts Options) func(y, d int) string {
 	era := fmtEra(locale, opts.Era)
 	layoutYear := fmtYearGregorian(locale)
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 	day := fmtDay(digits, opts.Day)
 	dayName := unitName(locale).Day
 	prefix, middle, suffix := era+" ", " ("+dayName+": ", ")"
 
 	return func(y, d int) string {
-		return prefix + layoutYear(year(y, opts.Year)) + middle + day(d) + suffix
+		return prefix + layoutYear(year(y)) + middle + day(d) + suffix
 	}
 }

--- a/fmt_gym.go
+++ b/fmt_gym.go
@@ -12,7 +12,7 @@ func fmtEraYearMonthGregorian(locale language.Tag, digits digits, opts Options) 
 
 	lang, script, region := locale.Raw()
 	era := fmtEra(locale, opts.Era)
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 	layoutYear := fmtYearGregorian(locale)
 	monthName := unitName(locale).Month
 
@@ -192,11 +192,11 @@ func fmtEraYearMonthGregorian(locale language.Tag, digits digits, opts Options) 
 	switch layout {
 	default: // eraYearMonth
 		return func(y int, m time.Month) string {
-			return prefix + layoutYear(year(y, opts.Year)) + middle + month(m) + suffix
+			return prefix + layoutYear(year(y)) + middle + month(m) + suffix
 		}
 	case eraMonthYear:
 		return func(y int, m time.Month) string {
-			return prefix + month(m) + middle + layoutYear(year(y, opts.Year)) + suffix
+			return prefix + month(m) + middle + layoutYear(year(y)) + suffix
 		}
 	}
 }
@@ -204,7 +204,7 @@ func fmtEraYearMonthGregorian(locale language.Tag, digits digits, opts Options) 
 func fmtEraYearMonthPersian(locale language.Tag, digits digits, opts Options) func(y int, m time.Month) string {
 	lang, _, region := locale.Raw()
 	era := fmtEra(locale, opts.Era)
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 	layoutYear := fmtYearPersian(locale)
 
 	const (
@@ -238,21 +238,21 @@ func fmtEraYearMonthPersian(locale language.Tag, digits digits, opts Options) fu
 	switch layout {
 	default: // eraYearMonth
 		return func(y int, m time.Month) string {
-			return prefix + layoutYear(year(y, opts.Year)) + middle + month(m) + suffix
+			return prefix + layoutYear(year(y)) + middle + month(m) + suffix
 		}
 	case eraMonthYear:
 		return func(y int, m time.Month) string {
-			return prefix + month(m) + middle + layoutYear(year(y, opts.Year)) + suffix
+			return prefix + month(m) + middle + layoutYear(year(y)) + suffix
 		}
 	}
 }
 
 func fmtEraYearMonthBuddhist(locale language.Tag, digits digits, opts Options) func(y int, m time.Month) string {
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 	layoutYear := fmtYearBuddhist(locale, opts.Era)
 	month := fmtMonth(digits, opts.Month)
 
 	return func(y int, m time.Month) string {
-		return month(m) + " " + layoutYear(year(y, opts.Year))
+		return month(m) + " " + layoutYear(year(y))
 	}
 }

--- a/fmt_gymd.go
+++ b/fmt_gymd.go
@@ -16,7 +16,7 @@ func fmtEraYearMonthDayGregorian(
 
 	lang, script, region := locale.Raw()
 	era := fmtEra(locale, opts.Era)
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 
 	const (
 		eraYearMonthDay = iota
@@ -273,19 +273,19 @@ func fmtEraYearMonthDayGregorian(
 	switch layout {
 	default: // eraYearMonthDay
 		return func(y int, m time.Month, d int) string {
-			return prefix + year(y, opts.Year) + separator + month(m) + separator + day(d) + suffix
+			return prefix + year(y) + separator + month(m) + separator + day(d) + suffix
 		}
 	case eraMonthDayYear:
 		return func(y int, m time.Month, d int) string {
-			return prefix + month(m) + separator + day(d) + separator + year(y, opts.Year) + suffix
+			return prefix + month(m) + separator + day(d) + separator + year(y) + suffix
 		}
 	case eraDayMonthYear:
 		return func(y int, m time.Month, d int) string {
-			return prefix + day(d) + separator + month(m) + separator + year(y, opts.Year) + suffix
+			return prefix + day(d) + separator + month(m) + separator + year(y) + suffix
 		}
 	case dayMonthEraYear:
 		return func(y int, m time.Month, d int) string {
-			return day(d) + separator + month(m) + separator + era + " " + year(y, opts.Year)
+			return day(d) + separator + month(m) + separator + era + " " + year(y)
 		}
 	}
 }
@@ -298,7 +298,7 @@ func fmtEraYearMonthDayPersian(
 	lang, _, region := locale.Raw()
 
 	era := fmtEra(locale, opts.Era)
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 
 	const (
 		eraYearMonthDay = iota
@@ -334,12 +334,12 @@ func fmtEraYearMonthDayPersian(
 	switch layout {
 	default: // eraMonthDayYear
 		return func(y int, m time.Month, d int) string {
-			return month(m) + separator + day(d) + separator + year(y, opts.Year) + suffix
+			return month(m) + separator + day(d) + separator + year(y) + suffix
 		}
 	case eraYearMonthDay:
 		return func(y int, m time.Month, d int) string {
 			// TODO(jhorsts): replace with the "prefix" variable (era + " ")
-			return era + " " + year(y, opts.Year) + separator + month(m) + separator + day(d)
+			return era + " " + year(y) + separator + month(m) + separator + day(d)
 		}
 	}
 }
@@ -350,11 +350,11 @@ func fmtEraYearMonthDayBuddhist(
 	opts Options,
 ) func(y int, m time.Month, d int) string {
 	era := fmtEra(locale, opts.Era)
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 	month := fmtMonth(digits, opts.Month)
 	day := fmtDay(digits, opts.Day)
 
 	return func(y int, m time.Month, d int) string {
-		return day(d) + "/" + month(m) + "/" + era + " " + year(y, opts.Year)
+		return day(d) + "/" + month(m) + "/" + era + " " + year(y)
 	}
 }

--- a/fmt_yd.go
+++ b/fmt_yd.go
@@ -7,7 +7,7 @@ import (
 func fmtYearDayGregorian(locale language.Tag, digits digits, opts Options) func(y, d int) string {
 	lang, script, _ := locale.Raw()
 	layoutYear := fmtYearGregorian(locale)
-	fmtYear := fmtYear(digits)
+	fmtYear := fmtYear(digits, opts.Year)
 
 	const (
 		layoutYearDay = iota
@@ -46,20 +46,20 @@ func fmtYearDayGregorian(locale language.Tag, digits digits, opts Options) func(
 
 	if layout == layoutDayYear {
 		return func(y, d int) string {
-			return fmtDay(d) + middle + layoutYear(fmtYear(y, opts.Year)) + suffix
+			return fmtDay(d) + middle + layoutYear(fmtYear(y)) + suffix
 		}
 	}
 
 	// layoutYearDay
 	return func(y, d int) string {
-		return layoutYear(fmtYear(y, opts.Year)) + middle + fmtDay(d) + suffix
+		return layoutYear(fmtYear(y)) + middle + fmtDay(d) + suffix
 	}
 }
 
 func fmtYearDayPersian(locale language.Tag, digits digits, opts Options) func(y, d int) string {
 	lang, _, region := locale.Raw()
 	layoutYear := fmtYearGregorian(locale)
-	fmtYear := fmtYear(digits)
+	fmtYear := fmtYear(digits, opts.Year)
 
 	prefix := ""
 	middle := " "
@@ -78,13 +78,13 @@ func fmtYearDayPersian(locale language.Tag, digits digits, opts Options) func(y,
 	fmtDay := fmtDayGregorian(locale, digits, opts.Day)
 
 	return func(y, d int) string {
-		return prefix + layoutYear(fmtYear(y, opts.Year)) + middle + fmtDay(d) + suffix
+		return prefix + layoutYear(fmtYear(y)) + middle + fmtDay(d) + suffix
 	}
 }
 
 func fmtYearDayBuddhist(locale language.Tag, digits digits, opts Options) func(y, d int) string {
 	layoutYear := fmtYearBuddhist(locale, EraNarrow)
-	fmtYear := fmtYear(digits)
+	fmtYear := fmtYear(digits, opts.Year)
 
 	middle := " "
 	suffix := ""
@@ -98,6 +98,6 @@ func fmtYearDayBuddhist(locale language.Tag, digits digits, opts Options) func(y
 	fmtDay := fmtDayBuddhist(locale, digits, opts.Day)
 
 	return func(y, d int) string {
-		return layoutYear(fmtYear(y, opts.Year)) + middle + fmtDay(d) + suffix
+		return layoutYear(fmtYear(y)) + middle + fmtDay(d) + suffix
 	}
 }

--- a/fmt_ym.go
+++ b/fmt_ym.go
@@ -11,7 +11,7 @@ func fmtYearMonthGregorian(locale language.Tag, digits digits, opts Options) fun
 	var month func(time.Month) string
 
 	lang, script, region := locale.Raw()
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 
 	const (
 		layoutYearMonth = iota
@@ -424,23 +424,23 @@ func fmtYearMonthGregorian(locale language.Tag, digits digits, opts Options) fun
 
 	if layout == layoutMonthYear {
 		return func(y int, m time.Month) string {
-			return prefix + month(m) + middle + year(y, opts.Year) + suffix
+			return prefix + month(m) + middle + year(y) + suffix
 		}
 	}
 
 	return func(y int, m time.Month) string {
-		return prefix + year(y, opts.Year) + middle + month(m) + suffix
+		return prefix + year(y) + middle + month(m) + suffix
 	}
 }
 
 func fmtYearMonthBuddhist(locale language.Tag, digits digits, opts Options) func(y int, m time.Month) string {
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 
 	if lang, _ := locale.Base(); lang == th {
 		month := fmtMonth(digits, opts.Month)
 
 		return func(y int, m time.Month) string {
-			return month(m) + "/" + year(y, opts.Year)
+			return month(m) + "/" + year(y)
 		}
 	}
 
@@ -448,13 +448,13 @@ func fmtYearMonthBuddhist(locale language.Tag, digits digits, opts Options) func
 	month := fmtMonth(digits, Month2Digit)
 
 	return func(y int, m time.Month) string {
-		return prefix + year(y, opts.Year) + "-" + month(m)
+		return prefix + year(y) + "-" + month(m)
 	}
 }
 
 func fmtYearMonthPersian(locale language.Tag, digits digits, opts Options) func(y int, m time.Month) string {
 	lang, _, region := locale.Raw()
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 	month := fmtMonth(digits, Month2Digit)
 
 	prefix := ""
@@ -467,7 +467,7 @@ func fmtYearMonthPersian(locale language.Tag, digits digits, opts Options) func(
 		// year=2-digit,month=numeric,out=١٠/٠٢
 		// year=2-digit,month=2-digit,out=١٠/٠٢
 		return func(y int, m time.Month) string {
-			return month(m) + "/" + year(y, opts.Year)
+			return month(m) + "/" + year(y)
 		}
 	case fa:
 		separator = "/"
@@ -489,6 +489,6 @@ func fmtYearMonthPersian(locale language.Tag, digits digits, opts Options) func(
 	}
 
 	return func(y int, m time.Month) string {
-		return prefix + year(y, opts.Year) + separator + month(m)
+		return prefix + year(y) + separator + month(m)
 	}
 }

--- a/fmt_ymd.go
+++ b/fmt_ymd.go
@@ -15,7 +15,7 @@ func fmtYearMonthDayGregorian(
 	var month func(time.Month) string
 
 	lang, script, region := locale.Raw()
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 
 	const (
 		layoutYearMonthDay = iota
@@ -834,9 +834,7 @@ func fmtYearMonthDayGregorian(
 		day := fmtDay(digits, opts.Day)
 
 		return func(y int, m time.Month, d int) string {
-			return day(d) + "/" +
-				month(m) + " " +
-				year(y, opts.Year)
+			return day(d) + "/" + month(m) + " " + year(y)
 		}
 	case ko:
 		// year=numeric,month=numeric,day=numeric,out=2024. 1. 2.
@@ -1301,9 +1299,7 @@ func fmtYearMonthDayGregorian(
 				day := fmtDay(digits, opts.Day)
 
 				return func(y int, m time.Month, d int) string {
-					return year(y, opts.Year) + "年" +
-						month(m) + "月" +
-						day(d) + "日"
+					return year(y) + "年" + month(m) + "月" + day(d) + "日"
 				}
 			}
 
@@ -1361,27 +1357,19 @@ func fmtYearMonthDayGregorian(
 	switch layout {
 	default: // layoutYearMonthDay
 		return func(y int, m time.Month, d int) string {
-			return prefix + year(y, opts.Year) + separator +
-				month(m) + separator +
-				day(d) + suffix
+			return prefix + year(y) + separator + month(m) + separator + day(d) + suffix
 		}
 	case layoutDayMonthYear:
 		return func(y int, m time.Month, d int) string {
-			return day(d) + separator +
-				month(m) + separator +
-				year(y, opts.Year) + suffix
+			return day(d) + separator + month(m) + separator + year(y) + suffix
 		}
 	case layoutMonthDayYear:
 		return func(y int, m time.Month, d int) string {
-			return month(m) + separator +
-				day(d) + separator +
-				year(y, opts.Year) + suffix
+			return month(m) + separator + day(d) + separator + year(y) + suffix
 		}
 	case layoutYearDayMonth:
 		return func(y int, m time.Month, d int) string {
-			return year(y, opts.Year) + separator +
-				day(d) + separator +
-				month(m) + suffix
+			return year(y) + separator + day(d) + separator + month(m) + suffix
 		}
 	}
 }
@@ -1393,7 +1381,7 @@ func fmtYearMonthDayPersian(
 ) func(y int, m time.Month, d int) string {
 	lang, _, region := locale.Raw()
 
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 
 	const (
 		layoutYearMonthDay = iota
@@ -1451,17 +1439,12 @@ func fmtYearMonthDayPersian(
 
 	if layout == layoutDayMonthYear {
 		return func(y int, m time.Month, d int) string {
-			return day(d) + "/" +
-				month(m) + "/" +
-				year(y, opts.Year)
+			return day(d) + "/" + month(m) + "/" + year(y)
 		}
 	}
 
 	return func(y int, m time.Month, d int) string {
-		return prefix +
-			year(y, opts.Year) + separator +
-			month(m) + separator +
-			day(d)
+		return prefix + year(y) + separator + month(m) + separator + day(d)
 	}
 }
 
@@ -1470,7 +1453,7 @@ func fmtYearMonthDayBuddhist(
 	digits digits,
 	opts Options,
 ) func(y int, m time.Month, d int) string {
-	year := fmtYear(digits)
+	year := fmtYear(digits, opts.Year)
 	month := fmtMonth(digits, opts.Month)
 	day := fmtDay(digits, opts.Day)
 
@@ -1484,8 +1467,6 @@ func fmtYearMonthDayBuddhist(
 	// year=2-digit,month=2-digit,day=numeric,out=2/01/24
 	// year=2-digit,month=2-digit,day=2-digit,out=02/01/24
 	return func(y int, m time.Month, d int) string {
-		return day(d) + "/" +
-			month(m) + "/" +
-			year(y, opts.Year)
+		return day(d) + "/" + month(m) + "/" + year(y)
 	}
 }

--- a/intl.go
+++ b/intl.go
@@ -408,12 +408,12 @@ func (f DateTimeFormat) Format(v time.Time) string {
 // fmtFunc is date time formatter for a particular calendar.
 type fmtFunc func(time.Time) string
 
-// fmtYear formats year as numeric.
-func fmtYear(digits digits) func(v int, opt Year) string {
-	return func(v int, opt Year) string {
-		s := strconv.Itoa(v)
+// fmtYear formats year.
+func fmtYear(digits digits, opt Year) func(v int) string {
+	if opt == Year2Digit {
+		return func(v int) string {
+			s := strconv.Itoa(v)
 
-		if opt == Year2Digit {
 			switch n := len(s); n {
 			default:
 				s = s[n-2:]
@@ -421,10 +421,12 @@ func fmtYear(digits digits) func(v int, opt Year) string {
 				s = "0" + s
 			case 0, 2: //nolint:mnd // noop, isSliceInBounds()
 			}
-		}
 
-		return digits.Sprint(s)
+			return digits.Sprint(s)
+		}
 	}
+
+	return func(v int) string { return digits.Sprint(strconv.Itoa(v)) }
 }
 
 // fmtMonth returns month formatting func.
@@ -578,10 +580,10 @@ func gregorianDateTimeFormat(locale language.Tag, digits digits, opts Options) f
 		}
 	case opts.Year != YearUnd:
 		layout := fmtYearGregorian(locale)
-		fmt := fmtYear(digits)
+		fmt := fmtYear(digits, opts.Year)
 
 		return func(v time.Time) string {
-			return layout(fmt(v.Year(), opts.Year))
+			return layout(fmt(v.Year()))
 		}
 	case opts.Month != MonthUnd:
 		layout := fmtMonthGregorian(locale, digits, opts.Month)
@@ -687,10 +689,10 @@ func persianDateTimeFormat(locale language.Tag, digits digits, opts Options) fmt
 		}
 	case opts.Year != YearUnd:
 		layout := fmtYearPersian(locale)
-		fmt := fmtYear(digits)
+		fmt := fmtYear(digits, opts.Year)
 
 		return func(v time.Time) string {
-			return layout(fmt(ptime.New(v).Year(), opts.Year))
+			return layout(fmt(ptime.New(v).Year()))
 		}
 	case opts.Month != MonthUnd:
 		layout := fmtMonthPersian(locale, digits, opts.Month)
@@ -805,12 +807,12 @@ func buddhistDateTimeFormat(locale language.Tag, digits digits, opts Options) fm
 		}
 	case opts.Year != YearUnd:
 		layout := fmtYearBuddhist(locale, EraNarrow)
-		fmt := fmtYear(digits)
+		fmt := fmtYear(digits, opts.Year)
 
 		return func(v time.Time) string {
 			v = v.AddDate(543, 0, 0) //nolint:mnd
 
-			return layout(fmt(v.Year(), opts.Year))
+			return layout(fmt(v.Year()))
 		}
 	case opts.Month != MonthUnd:
 		layout := fmtMonthBuddhist(locale, digits, opts.Month)


### PR DESCRIPTION
```console
$ gsa a b
┌────────────────────────────────────────────────────────────────────┐
│ Diff between a and b                                               │
├─────────┬──────────────────────────┬──────────┬──────────┬─────────┤
│ PERCENT │ NAME                     │ OLD SIZE │ NEW SIZE │ DIFF    │
├─────────┼──────────────────────────┼──────────┼──────────┼─────────┤
│ +1.27%  │ go.expect.digital/intl   │ 352 kB   │ 357 kB   │ +4.5 kB │
├─────────┼──────────────────────────┼──────────┼──────────┼─────────┤
│ +0.86%  │ __zdebug_ranges __DWARF  │ 47 kB    │ 48 kB    │ +407 B  │
│ +0.20%  │ __zdebug_line __DWARF    │ 152 kB   │ 152 kB   │ +303 B  │
│ +0.24%  │ __zdebug_frame __DWARF   │ 34 kB    │ 34 kB    │ +80 B   │
│ +0.01%  │ __gopclntab __DATA_CONST │ 94 kB    │ 94 kB    │ +10 B   │
│ -1.20%  │ __typelink __DATA_CONST  │ 2.0 kB   │ 2.0 kB   │ -24 B   │
│ -0.05%  │ __rodata __TEXT          │ 250 kB   │ 249 kB   │ -128 B  │
│ -0.06%  │ __zdebug_info __DWARF    │ 336 kB   │ 335 kB   │ -193 B  │
│ -0.15%  │ __zdebug_loc __DWARF     │ 166 kB   │ 166 kB   │ -248 B  │
│ -1.85%  │ __rodata __DATA_CONST    │ 268 kB   │ 263 kB   │ -5.0 kB │
├─────────┼──────────────────────────┼──────────┼──────────┼─────────┤
│ +0.03%  │ a                        │ 3.2 MB   │ 3.2 MB   │ +960 B  │
│         │ b                        │          │          │         │
└─────────┴──────────────────────────┴──────────┴──────────┴─────────┘