### PR TITLE
feat: add day+weekday formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Go version 1.24+.
 | year                   |     ✅︎    |
 | month                  |     ✅︎    |
 | day                    |     ✅︎    |
-| weekday (standalone)   |     ✅︎    |
+| weekday (standalone, day+weekday)   |     ✅︎    |
 | weekday (format)       |     ❌    |
 | hour                   |     ❌    |
 | minute                 |     ❌    |

--- a/fmt_de.go
+++ b/fmt_de.go
@@ -1,0 +1,160 @@
+package intl
+
+import (
+	"go.expect.digital/intl/internal/cldr"
+	"go.expect.digital/intl/internal/symbols"
+	"golang.org/x/text/language"
+)
+
+//nolint:gocognit,cyclop
+func seqDayWeekday(locale language.Tag, opts Options) *symbols.Seq {
+	lang, script, region := locale.Raw()
+	seq := symbols.NewSeq(locale)
+	weekday := opts.Weekday.symbolFormat()
+	day := opts.Day.symbol()
+
+	switch lang {
+	default:
+		return seq.Add(day, ',', ' ', weekday)
+	case cldr.AF, cldr.AM, cldr.AS, cldr.AST, cldr.BAS, cldr.BLO, cldr.BR, cldr.CA, cldr.DJE,
+		cldr.DOI, cldr.DUA, cldr.DYO, cldr.EE, cldr.EL, cldr.ES, cldr.FR, cldr.GA, cldr.GL, cldr.GU,
+		cldr.HAW, cldr.HI, cldr.IA, cldr.IE, cldr.IT, cldr.JGO, cldr.KKJ, cldr.KSF, cldr.KXV,
+		cldr.LN, cldr.LU, cldr.MAI, cldr.MGH, cldr.MUA, cldr.NL, cldr.NMG, cldr.NUS, cldr.RM,
+		cldr.RN, cldr.RO, cldr.SA, cldr.SBP, cldr.SC, cldr.SCN, cldr.SU, cldr.SV, cldr.SW, cldr.TH,
+		cldr.TO, cldr.TWQ, cldr.VEC, cldr.XNR, cldr.YAV:
+		return seq.Add(weekday, ' ', day)
+	case cldr.AGQ, cldr.BN, cldr.CCP, cldr.CEB, cldr.CHR, cldr.DZ, cldr.EWO, cldr.FIL, cldr.FUR,
+		cldr.KA, cldr.KM, cldr.KN, cldr.MR, cldr.MS, cldr.NE, cldr.OR, cldr.PCM, cldr.SI, cldr.TA,
+		cldr.TI, cldr.TK, cldr.TR, cldr.UG, cldr.UR, cldr.YUE, cldr.ZU:
+		return seq.Add(day, ' ', weekday)
+	case cldr.AR, cldr.SYR:
+		return seq.Add(weekday, symbols.TxtArabicComma, ' ', day)
+	case cldr.AZ:
+		if opts.Weekday == WeekdayNarrow && opts.Day.numeric() {
+			return seq.Add(weekday, ' ', day)
+		}
+
+		return seq.Add(day, ' ', weekday)
+	case cldr.BG, cldr.ET, cldr.GD, cldr.HA, cldr.ID, cldr.JV, cldr.KEA, cldr.KGP, cldr.LO, cldr.MI,
+		cldr.MK, cldr.PL, cldr.PT, cldr.RU, cldr.RW, cldr.SQ, cldr.UK, cldr.WO, cldr.YO, cldr.YRL:
+		return seq.Add(weekday, ',', ' ', day)
+	case cldr.BS, cldr.DE, cldr.DSB, cldr.HR, cldr.HSB, cldr.LB, cldr.LV, cldr.SL:
+		return seq.Add(weekday, ',', ' ', day, '.')
+	case cldr.CKB:
+		return seq.Add(weekday, ' ', day, symbols.TxtKurdishHam)
+	case cldr.CS, cldr.FI, cldr.FO, cldr.GSW, cldr.IS, cldr.NB, cldr.NN, cldr.NO, cldr.SK, cldr.SMN,
+		cldr.SR, cldr.WAE:
+		return seq.Add(weekday, ' ', day, '.')
+	case cldr.DA:
+		return seq.Add(weekday, symbols.TxtDanishDen, day, '.')
+	case cldr.EN:
+		if script == cldr.Dsrt || script == cldr.Shaw {
+			return seq.Add(day, ' ', weekday)
+		}
+
+		switch region {
+		default:
+			return seq.Add(weekday, ' ', day)
+		case cldr.RegionAS, cldr.RegionBI, cldr.RegionGU, cldr.RegionJP, cldr.RegionMH,
+			cldr.RegionMP, cldr.RegionPH, cldr.RegionPR, cldr.RegionUM, cldr.RegionUS, cldr.RegionVI,
+			cldr.RegionZZ:
+			return seq.Add(day, ' ', weekday)
+		}
+	case cldr.FA:
+		return seq.Add(weekday, ' ', day, symbols.TxtPersianOrdinalSuffix)
+	case cldr.FF:
+		if script == cldr.Adlm {
+			return seq.Add(weekday, ' ', day)
+		}
+
+		return seq.Add(day, ',', ' ', weekday)
+	case cldr.HE:
+		return seq.Add(weekday, symbols.TxtHebrewHeDash, day)
+	case cldr.HU:
+		return seq.Add(day, '.', ',', ' ', weekday)
+	case cldr.II:
+		if opts.Weekday == WeekdayNarrow {
+			return seq.Add(day, weekday, ',', ' ', symbols.Txtꑍ)
+		}
+
+		return seq.Add(day, symbols.Txtꑍ, ',', ' ', weekday)
+	case cldr.JA:
+		if opts.Weekday == WeekdayLong {
+			return seq.Add(day, symbols.Txt日, weekday)
+		}
+
+		return seq.Add(day, symbols.Txt日, '(', weekday, ')')
+	case cldr.KK:
+		if script == cldr.Arab {
+			return seq.Add(day, ' ', weekday)
+		}
+
+		return seq.Add(day, ',', ' ', weekday)
+	case cldr.KO:
+		if opts.Weekday == WeekdayLong {
+			return seq.Add(day, symbols.Txt일, ' ', weekday)
+		}
+
+		return seq.Add(day, symbols.Txt일, ' ', '(', weekday, ')')
+	case cldr.KS:
+		if script == cldr.Deva {
+			return seq.Add(day, ',', ' ', weekday)
+		}
+
+		return seq.Add(day, ' ', weekday)
+	case cldr.KSH:
+		return seq.Add(weekday, symbols.TxtColognianDa, day, '.')
+	case cldr.MN:
+		if opts.Day.twoDigit() {
+			return seq.Add(day, '.', ' ', weekday)
+		}
+
+		return seq.Add('0', day, '.', ' ', weekday)
+	case cldr.MY:
+		return seq.Add(day, symbols.TxtBurmeseDay, weekday)
+	case cldr.SD:
+		if script == cldr.Deva {
+			return seq.Add(day, ' ', weekday)
+		}
+
+		return seq.Add(day, ',', ' ', weekday)
+	case cldr.SE:
+		if region == cldr.RegionFI {
+			return seq.Add(day, ' ', weekday)
+		}
+
+		return seq.Add(day, ',', ' ', weekday)
+	case cldr.SHN:
+		return seq.Add(day, ' ', '-', ' ', weekday)
+	case cldr.TOK:
+		if opts.Weekday == WeekdayNarrow && opts.Day.numeric() {
+			return seq.Add(weekday, ',', ' ', day)
+		}
+
+		return seq.Add(day, ',', ' ', weekday)
+	case cldr.VAI:
+		if script == cldr.Latn {
+			return seq.Add(weekday, ' ', day)
+		}
+
+		return seq.Add(day, ',', ' ', weekday)
+	case cldr.VI:
+		return seq.Add(weekday, symbols.TxtVietnameseNgay, day)
+	case cldr.YI:
+		return seq.Add(weekday, symbols.TxtYiddishDem, day, symbols.TxtYiddishTn)
+	case cldr.ZH:
+		if script == cldr.Hant {
+			return seq.Add(day, ' ', weekday)
+		}
+
+		return seq.Add(day, symbols.Txt日, weekday)
+	}
+}
+
+func seqDayWeekdayBuddhist(locale language.Tag, opts Options) *symbols.Seq {
+	return seqDayWeekday(locale, opts)
+}
+
+func seqDayWeekdayPersian(locale language.Tag, opts Options) *symbols.Seq {
+	return seqDayWeekday(locale, opts)
+}

--- a/fmt_de.go
+++ b/fmt_de.go
@@ -105,11 +105,7 @@ func seqDayWeekday(locale language.Tag, opts Options) *symbols.Seq {
 	case cldr.KSH:
 		return seq.Add(weekday, symbols.TxtColognianDa, day, '.')
 	case cldr.MN:
-		if opts.Day.twoDigit() {
-			return seq.Add(day, '.', ' ', weekday)
-		}
-
-		return seq.Add('0', day, '.', ' ', weekday)
+		return seq.Add(symbols.Symbol_dd, '.', ' ', weekday)
 	case cldr.MY:
 		return seq.Add(day, symbols.TxtBurmeseDay, weekday)
 	case cldr.SD:

--- a/internal/cldr/locale.go
+++ b/internal/cldr/locale.go
@@ -263,15 +263,23 @@ var (
 var (
 	Adlm = language.MustParseScript("Adlm")
 	Arab = language.MustParseScript("Arab")
+	Beng = language.MustParseScript("Beng")
 	Cyrl = language.MustParseScript("Cyrl")
 	Deva = language.MustParseScript("Deva")
 	Dsrt = language.MustParseScript("Dsrt")
+	Guru = language.MustParseScript("Guru")
 	Hans = language.MustParseScript("Hans")
 	Hant = language.MustParseScript("Hant")
 	Latn = language.MustParseScript("Latn")
+	Mong = language.MustParseScript("Mong")
+	Mtei = language.MustParseScript("Mtei")
+	Nkoo = language.MustParseScript("Nkoo")
+	Olck = language.MustParseScript("Olck")
 	Orya = language.MustParseScript("Orya")
 	Shaw = language.MustParseScript("Shaw")
 	Telu = language.MustParseScript("Telu")
+	Tfng = language.MustParseScript("Tfng")
+	Vaii = language.MustParseScript("Vaii")
 )
 
 // Regions.

--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -9,56 +9,66 @@ type Symbol byte
 
 //nolint:asciicheck,revive
 const (
-	Txt日              Symbol = iota + 128 // "日"
-	Txt일                                  // "일"
-	Txtꑍ                                  // "ꑍ"
-	Txt年                                  // "年"
-	Txt月                                  // "月"
-	Txt년                                  // "년"
-	Txtс                                  // "с"
-	Txtҫ                                  // "ҫ"
-	Txtж                                  // "ж"
-	Txtթ                                  // "թ"
-	TxtNNBSP                              // " "
-	Txtр                                  // "р"
-	Txt00                                 // "г."
-	Txt01                                 // ". g."
-	Txt02                                 // "\u200f/"
-	Txt03                                 // "ꆪ-"
-	Txt04                                 // "tháng "
-	Txt05                                 // "ел"
-	Txt06                                 // "སྤྱི་ཟླ་"
-	Txt08                                 // "urteko"
-	Txt09                                 // "an"
-	Txt10                                 // "оны"
-	TxtArabicComma                        // "،"
-	TxtCyrillicShortI                     // "й"
-	symbolStart                           // the start of CLDR symbols
-	MonthUnit                             // "month" in the local language
-	DayUnit                               // "day" in the local language
-	Symbol_G                              // G, era, abbreviated
-	Symbol_GGGG                           // GGGG, era, long
-	Symbol_GGGGG                          // GGGGG, era, narrow
-	Symbol_y                              // y, year
-	Symbol_yy                             // yy, two-digit year
-	Symbol_M                              // M, month
-	Symbol_MM                             // MM, two-digit month
-	Symbol_d                              // d, day
-	Symbol_dd                             // dd, two-digit day
-	Symbol_LLL                            // LLL, stand-alone abbreviated
-	Symbol_LLLLL                          // LLLLL, stand-alone narrow
-	Symbol_MMM                            // MMM, format abbreviated
-	Symbol_MMMMM                          // MMMMM, format narrow
-	Symbol_E                              // E, format abbreviated
-	Symbol_EEEE                           // EEEE, format wide
-	Symbol_EEEEE                          // EEEEE, format narrow
-	Symbol_EEEEEE                         // EEEEEE, format short
-	Symbol_ccc                            // ccc, stand-alone abbreviated
-	Symbol_cccc                           // cccc, stand-alone wide
-	Symbol_ccccc                          // ccccc, stand-alone narrow
-	Symbol_cccccc                         // cccccc, stand-alone short
+	Txt日                    Symbol = iota + 128 // "日"
+	Txt일                                        // "일"
+	Txtꑍ                                        // "ꑍ"
+	Txt年                                        // "年"
+	Txt月                                        // "月"
+	Txt년                                        // "년"
+	Txtс                                        // "с"
+	Txtҫ                                        // "ҫ"
+	Txtж                                        // "ж"
+	Txtթ                                        // "թ"
+	TxtNNBSP                                    // " "
+	Txtр                                        // "р"
+	Txt00                                       // "г."
+	Txt01                                       // ". g."
+	Txt02                                       // "\u200f/"
+	Txt03                                       // "ꆪ-"
+	Txt04                                       // "tháng "
+	Txt05                                       // "ел"
+	Txt06                                       // "སྤྱི་ཟླ་"
+	Txt08                                       // "urteko"
+	Txt09                                       // "an"
+	Txt10                                       // "оны"
+	TxtArabicComma                              // "،"
+	TxtCyrillicShortI                           // "й"
+	TxtKurdishHam                               // "ھەم"
+	TxtPersianOrdinalSuffix                     // "م"
+	TxtHebrewHeDash                             // " ה-"
+	TxtColognianDa                              // " dä "
+	TxtBurmeseDay                               // " ရက် "
+	TxtVietnameseNgay                           // ", ngày "
+	TxtYiddishDem                               // " דעם "
+	TxtYiddishTn                                // "טן"
+	TxtDanishDen                                // " den "
+	symbolStart                                 // the start of CLDR symbols
+	MonthUnit                                   // "month" in the local language
+	DayUnit                                     // "day" in the local language
+	Symbol_G                                    // G, era, abbreviated
+	Symbol_GGGG                                 // GGGG, era, long
+	Symbol_GGGGG                                // GGGGG, era, narrow
+	Symbol_y                                    // y, year
+	Symbol_yy                                   // yy, two-digit year
+	Symbol_M                                    // M, month
+	Symbol_MM                                   // MM, two-digit month
+	Symbol_d                                    // d, day
+	Symbol_dd                                   // dd, two-digit day
+	Symbol_LLL                                  // LLL, stand-alone abbreviated
+	Symbol_LLLLL                                // LLLLL, stand-alone narrow
+	Symbol_MMM                                  // MMM, format abbreviated
+	Symbol_MMMMM                                // MMMMM, format narrow
+	Symbol_E                                    // E, format abbreviated
+	Symbol_EEEE                                 // EEEE, format wide
+	Symbol_EEEEE                                // EEEEE, format narrow
+	Symbol_EEEEEE                               // EEEEEE, format short
+	Symbol_ccc                                  // ccc, stand-alone abbreviated
+	Symbol_cccc                                 // cccc, stand-alone wide
+	Symbol_ccccc                                // ccccc, stand-alone narrow
+	Symbol_cccccc                               // cccccc, stand-alone short
 )
 
+//nolint:cyclop
 func (s Symbol) String() string {
 	switch s {
 	default:
@@ -111,6 +121,24 @@ func (s Symbol) String() string {
 		return "،"
 	case TxtCyrillicShortI:
 		return "й"
+	case TxtKurdishHam:
+		return "ھەم"
+	case TxtPersianOrdinalSuffix:
+		return "م"
+	case TxtHebrewHeDash:
+		return " ה-"
+	case TxtColognianDa:
+		return " dä "
+	case TxtBurmeseDay:
+		return " ရက် "
+	case TxtVietnameseNgay:
+		return ", ngày "
+	case TxtYiddishDem:
+		return " דעם "
+	case TxtYiddishTn:
+		return "טן"
+	case TxtDanishDen:
+		return " den "
 	}
 }
 

--- a/intl.go
+++ b/intl.go
@@ -414,6 +414,19 @@ func (wd Weekday) symbol() symbols.Symbol {
 	}
 }
 
+func (wd Weekday) symbolFormat() symbols.Symbol {
+	switch wd {
+	default:
+		return symbols.Symbol_E
+	case WeekdayLong:
+		return symbols.Symbol_EEEE
+	case WeekdayNarrow:
+		return symbols.Symbol_EEEEE
+	case WeekdayShort:
+		return symbols.Symbol_E
+	}
+}
+
 // ParseWeekday converts a string representation of a weekday format to the [Weekday] type.
 func ParseWeekday(s string) (Weekday, error) {
 	switch s {
@@ -539,6 +552,8 @@ func gregorianDateTimeFormat(locale language.Tag, opts Options) cldr.Fmt {
 		seq = seqMonthDay(locale, opts)
 	case !opts.Month.und():
 		seq = seqMonth(locale, opts.Month)
+	case !opts.Day.und() && !opts.Weekday.und():
+		seq = seqDayWeekday(locale, opts)
 	case !opts.Day.und():
 		seq = seqDay(locale, opts.Day)
 	case !opts.Weekday.und():
@@ -581,6 +596,8 @@ func persianDateTimeFormat(locale language.Tag, opts Options) cldr.Fmt {
 		seq = seqMonthDayPersian(locale, opts)
 	case !opts.Month.und():
 		seq = seqMonthPersian(locale, opts.Month)
+	case !opts.Day.und() && !opts.Weekday.und():
+		seq = seqDayWeekdayPersian(locale, opts)
 	case !opts.Day.und():
 		seq = seqDayPersian(locale, opts.Day)
 	case !opts.Weekday.und():
@@ -623,6 +640,8 @@ func buddhistDateTimeFormat(locale language.Tag, opts Options) cldr.Fmt {
 		seq = seqMonthDayBuddhist(locale, opts)
 	case !opts.Month.und():
 		seq = seqMonthBuddhist(locale, opts.Month)
+	case !opts.Day.und() && !opts.Weekday.und():
+		seq = seqDayWeekdayBuddhist(locale, opts)
 	case !opts.Day.und():
 		seq = seqDayBuddhist(locale, opts.Day)
 	case !opts.Weekday.und():

--- a/testdata.js
+++ b/testdata.js
@@ -50,6 +50,16 @@ function generateTests(locales) {
       ]);
     });
 
+    ["long", "short", "narrow"].forEach((weekday) => {
+      ["numeric", "2-digit"].forEach((day) => {
+        const options = { weekday, day };
+        result.push([
+          options,
+          new Intl.DateTimeFormat(locale, options).format(date),
+        ]);
+      });
+    });
+
     [undefined, "long", "short", "narrow"].forEach((era) => {
       [undefined, "numeric", "2-digit"].forEach((year) => {
         [undefined, "numeric", "2-digit"].forEach((month) => {


### PR DESCRIPTION
Adds full support for combined day + weekday locale-aware formatting (e.g. Tuesday 2 or 2 Tuesday) matching JS Intl.DateTimeFormat behaviour across Gregorian, Persian, and Buddhist calendars.